### PR TITLE
feat: better auth checkout endpoint

### DIFF
--- a/package/src/libraries/backend/better-auth.ts
+++ b/package/src/libraries/backend/better-auth.ts
@@ -23,7 +23,7 @@ import {
   CreateReferralCodeParamsSchema,
   RedeemReferralCodeParamsSchema,
 } from "@sdk/referrals/referralTypes";
-import { AttachParamsSchema } from "@sdk/general/attachTypes";
+import { AttachParamsSchema, CheckoutParamsSchema } from "@sdk/general/attachTypes";
 
 const router = createRouterWithOptions();
 
@@ -157,7 +157,7 @@ export const autumn = (options?: { url?: string; secretKey?: string }) => {
         "/autumn/checkout",
         {
           method: "POST",
-          body: AttachParamsSchema.omit({
+          body: CheckoutParamsSchema.omit({
             customer_id: true,
           }),
           use: [sessionMiddleware],

--- a/package/src/libraries/backend/better-auth.ts
+++ b/package/src/libraries/backend/better-auth.ts
@@ -30,6 +30,7 @@ const router = createRouterWithOptions();
 const betterAuthPathMap: Record<string, string> = {
   // "create-customer": "customers",
   // "customers/get": "customers",
+  "checkout": "checkout",
   attach: "attach",
   check: "check",
   track: "track",
@@ -151,6 +152,17 @@ export const autumn = (options?: { url?: string; secretKey?: string }) => {
         async (ctx) => {
           return await handleReq({ ctx, options, method: "GET" });
         }
+      ),
+      checkout: createAuthEndpoint(
+        "/autumn/checkout",
+        {
+          method: "POST",
+          body: AttachParamsSchema.omit({
+            customer_id: true,
+          }),
+          use: [sessionMiddleware],
+        },
+        async (ctx) => handleReq({ ctx, options, method: "POST" })
       ),
       attach: createAuthEndpoint(
         "/autumn/attach",


### PR DESCRIPTION
currently, the better-auth plugin is missing the `checkout` endpoint, which this PR adds.