### PR TITLE
fix: Fix import from better-auth

### DIFF
--- a/package/src/libraries/backend/better-auth.ts
+++ b/package/src/libraries/backend/better-auth.ts
@@ -11,7 +11,7 @@ import { secretKeyCheck } from "./utils/secretKeyCheck";
 import { BillingPortalParamsSchema, CustomerExpandEnum } from "@sdk";
 import { Autumn } from "../../sdk/client";
 import { findRoute } from "rou3";
-import { sessionMiddleware } from "better-auth/api";
+import { sessionMiddleware, getSessionFromCtx } from "better-auth/api";
 import { z } from "zod/v4";
 
 import {
@@ -263,4 +263,4 @@ export const autumnClient = () =>
   ({
     id: "autumn",
     $InferServerPlugin: {} as ReturnType<typeof autumn>,
-  }) satisfies BetterAuthClientPlugin;
+  } satisfies BetterAuthClientPlugin);


### PR DESCRIPTION
Self descriptive: The `getSessionFromCtx` function was not imported at all, throwing typescript error.