### PR TITLE
fix: 🐛 required balance in check() not obeyed

### DIFF
--- a/package/src/libraries/react/hooks/helpers/handleCheck.ts
+++ b/package/src/libraries/react/hooks/helpers/handleCheck.ts
@@ -81,6 +81,7 @@ const handleFeatureCheck = ({
   let { cusFeature, requiredBalance } = getCusFeature({
     customer,
     featureId: params.featureId!,
+    ...(params.requiredBalance ? { requiredBalance: params.requiredBalance } : {}),
   });
 
   let allowed = getFeatureAllowed({ cusFeature, requiredBalance });


### PR DESCRIPTION
fixes the react useCustomer().check not obeying the set requiredBalance