### PR TITLE
fix: prevent checkoutSessionparams snake_case normalization

### DIFF
--- a/package/src/libraries/react/client/clientGenMethods.ts
+++ b/package/src/libraries/react/client/clientGenMethods.ts
@@ -25,7 +25,7 @@ export async function checkoutMethod(
   this: AutumnClient,
   params: CheckoutParams
 ): AutumnPromise<CheckoutResult> {
-  let snakeParams = toSnakeCase(params);
+  let snakeParams = toSnakeCase(params, ["checkoutSessionparams"]);
   const res = await this.post(`${this.prefix}/checkout`, snakeParams);
   return res;
 }


### PR DESCRIPTION
This PR fixes an issue where the entire checkout parameters object is being normalized. This behavior is undesirable, as many other libraries and services that integrate with Stripe rely on metadata keys remaining in camelCase (e.g. [dubCustomerId](https://dub.co/docs/conversions/sales/stripe#option-2%3A-using-stripe-checkout-recommended)).

